### PR TITLE
Fixes for use without window manager

### DIFF
--- a/src/xlib.c
+++ b/src/xlib.c
@@ -226,6 +226,16 @@ void handlekeypress(XEvent *event){
 
 void handleevent(XEvent *event){
 	switch(event->type){
+		/* Might not get ConfigureNotify, for example if there's no window manager */
+		case MapNotify:
+			if (!width || !height)
+			{
+				XWindowAttributes attr;
+				XGetWindowAttributes(event->xmap.display, event->xmap.window, &attr);
+				width = attr.width;
+				height = attr.height;
+			}
+			break;	
 		case ConfigureNotify:
 			if(width != event->xconfigure.width || height != event->xconfigure.height){
 				width = event->xconfigure.width;


### PR DESCRIPTION
These changes make it possible to use meh on a system running X without a window manager. In this case, no ConfigureNotify event will be received, so also handle MapNotify events to make sure we have valid height and width.
This change also exposed a race condition: XSelectInput must be called before XMapRaised or the MapNotify event may be lost.
