### PR TITLE
fixed for API change in DGifCloseFile (giflib 5.1)

### DIFF
--- a/src/gif.c
+++ b/src/gif.c
@@ -96,7 +96,24 @@ error:
 
 void gif_close(struct image *img){
 	struct gif_t *g = (struct gif_t *)img;
+#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1)
+	int ret;
+#endif
+
+#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1)
+	DGifCloseFile(g->gif,&ret);
+	if(ret != GIF_OK) {
+#if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5
+		fprintf(stderr, "GIFLIB: %s\n", GifErrorString(ret));
+#elif defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && ((GIFLIB_MAJOR == 4 && GIFLIB_MINOR >= 2) || GIFLIB_MAJOR > 4)
+		fprintf(stderr, "GIFLIB: %s\n", GifErrorString());
+#else
+		PrintGifError();
+#endif
+	}
+#else
 	DGifCloseFile(g->gif);
+#endif
 	fclose(g->f);
 }
 


### PR DESCRIPTION
Small API change (in a minor version of giflib) adding an error paramter to DGifCloseFile.
