### PR TITLE
src/meh.h: add missing sys/select.h, fixes musl compilation

### DIFF
--- a/src/meh.h
+++ b/src/meh.h
@@ -2,6 +2,7 @@
 #define MEH_H MEH_H
 
 #include <stdio.h>
+#include <sys/select.h> /* for fd_set */
 
 struct image;
 


### PR DESCRIPTION
fixes #17 

error log in case fix isn't present:

```
cc -O3 -DNDEBUG -MMD -MP -MT "src/netpbm.d" -c -o src/netpbm.o src/netpbm.c
In file included from src/netpbm.c:6:0:
src/meh.h:50:15: error: unknown type name 'fd_set'; did you mean 'fpos_t'?
 int setup_fds(fd_set *fds);
               ^~~~~~
               fpos_t
src/meh.h:51:17: error: unknown type name 'fd_set'; did you mean 'fpos_t'?
 int process_fds(fd_set *fds);
                 ^~~~~~
                 fpos_t
make: *** [Makefile:34: src/netpbm.o] Error 1
```