### PR TITLE
Add a default key action

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -118,6 +118,11 @@ void key_quit(){
 	exit(EXIT_SUCCESS);
 }
 
+void key_default(char *key){
+	printf("%s %s\n", key, images[imageidx]);
+	fflush(stdout);
+}
+
 void key_action(){
 	puts(images[imageidx]);
 	fflush(stdout);

--- a/src/meh.h
+++ b/src/meh.h
@@ -46,6 +46,7 @@ void key_next();
 void key_prev();
 void key_quit();
 void key_action();
+void key_default(char *key);
 
 /* callbacks from backend */
 int setup_fds(fd_set *fds);

--- a/src/xlib.c
+++ b/src/xlib.c
@@ -220,6 +220,8 @@ void handlekeypress(XEvent *event){
 			if(curimg)
 				XResizeWindow(display, window, curimg->bufwidth, curimg->bufheight);
 			break;
+		default:
+			key_default(XKeysymToString(key));
 	}
 }
 


### PR DESCRIPTION
If a key is pressed without an assigned action, print the key and
filename to stout.

This is very handy for scripting.
t allowed me to assign ratings, sort them, rotate them with ImageMagick, etc.. 